### PR TITLE
Update manifest.json with new urls

### DIFF
--- a/custom_components/ha_kia_hyundai/manifest.json
+++ b/custom_components/ha_kia_hyundai/manifest.json
@@ -3,9 +3,9 @@
   "name": "Kia US",
   "codeowners": ["@MarcusTaz"],
   "config_flow": true,
-  "documentation": "https://github.com/dahlb/ha_kia_hyundai",
+  "documentation": "https://github.com/MarcusTaz/ha_kia_hyundai_USA",
   "iot_class": "cloud_polling",
-  "issue_tracker": "https://github.com/dahlb/ha_kia_hyundai/issues",
+  "issue_tracker": "https://github.com/MarcusTaz/ha_kia_hyundai_USA/issues",
   "loggers": ["ha_kia_hyundai", "kia_hyundai_api"],
   "requirements": ["kia-hyundai-api==1.6.4"],
   "version": "1.0.0"


### PR DESCRIPTION
This updates the documentation and issue urls so that when you go to those pages in the integration it will send you back to the right github project.