### PR TITLE
Port latest USA BlueLink API updates

### DIFF
--- a/custom_components/ha_kia_hyundai/kia_hyundai_api/us_genesis.py
+++ b/custom_components/ha_kia_hyundai/kia_hyundai_api/us_genesis.py
@@ -291,7 +291,7 @@ class UsGenesis:
     async def _post_request_with_logging_and_errors_raised(
             self,
             url: str,
-            json_body: dict,
+            json_body: dict | None = None,
             headers: dict | None = None,
     ) -> ClientResponse:
         if headers is None:
@@ -302,6 +302,28 @@ class UsGenesis:
             headers=headers,
             ssl=await self.get_ssl_context()
         )
+
+    def _get_transaction_id(self, response: ClientResponse) -> str | None:
+        """Return the BlueLink transaction ID from a command response."""
+        for key in ("tmsTid", "transactionId", "Xid"):
+            if key in response.headers:
+                return response.headers[key]
+        _LOGGER.warning(
+            "Genesis command response did not include a transaction ID: %s",
+            dict(response.headers),
+        )
+        return None
+
+    def _set_last_action_from_response(self, name: str, response: ClientResponse) -> None:
+        """Track command transaction ID so refresh can wait for completion."""
+        transaction_id = self._get_transaction_id(response)
+        if transaction_id is None:
+            self.last_action = None
+            return
+        self.last_action = {
+            "name": name,
+            "id": transaction_id,
+        }
 
     @request_with_logging_bluelink
     async def _get_request_with_logging_and_errors_raised(
@@ -667,6 +689,7 @@ class UsGenesis:
             headers=headers,
         )
         _LOGGER.debug("Genesis lock response: %s", await response.text())
+        self._set_last_action_from_response("lock", response)
 
     async def unlock(self, vehicle_id: str):
         """Unlock the vehicle."""
@@ -687,6 +710,7 @@ class UsGenesis:
             headers=headers,
         )
         _LOGGER.debug("Genesis unlock response: %s", await response.text())
+        self._set_last_action_from_response("unlock", response)
 
     async def start_climate(
             self,
@@ -766,6 +790,7 @@ class UsGenesis:
             headers=headers,
         )
         _LOGGER.debug("Genesis start_climate response: %s", await response.text())
+        self._set_last_action_from_response("start_climate", response)
 
     async def stop_climate(self, vehicle_id: str):
         """Stop climate control."""
@@ -787,6 +812,7 @@ class UsGenesis:
             headers=headers,
         )
         _LOGGER.debug("Genesis stop_climate response: %s", await response.text())
+        self._set_last_action_from_response("stop_climate", response)
 
     async def start_charge(self, vehicle_id: str):
         """Start charging (EV only)."""
@@ -806,6 +832,7 @@ class UsGenesis:
             headers=headers,
         )
         _LOGGER.debug("Genesis start_charge response: %s", await response.text())
+        self._set_last_action_from_response("start_charge", response)
 
     async def stop_charge(self, vehicle_id: str):
         """Stop charging (EV only)."""
@@ -825,6 +852,7 @@ class UsGenesis:
             headers=headers,
         )
         _LOGGER.debug("Genesis stop_charge response: %s", await response.text())
+        self._set_last_action_from_response("stop_charge", response)
 
     async def set_charge_limits(
             self,
@@ -856,7 +884,53 @@ class UsGenesis:
             headers=headers,
         )
         _LOGGER.debug("Genesis set_charge_limits response: %s", await response.text())
+        self._set_last_action_from_response("set_charge_limits", response)
 
     async def check_last_action_finished(self, vehicle_id: str) -> bool:
-        """Check if last action is finished (placeholder for compatibility)."""
+        """Check whether the last tracked Genesis command has completed."""
+        if self.last_action is None:
+            return True
+
+        action_id = self.last_action.get("id")
+        if not action_id:
+            self.last_action = None
+            return True
+
+        await self._ensure_token_valid()
+        vehicle = await self.find_vehicle(vehicle_id)
+        headers = self._get_vehicle_headers(vehicle)
+        headers["tid"] = action_id
+        headers["login_id"] = self.username
+        headers["service_type"] = "REMOTE_POLL"
+
+        url = GENESIS_API_URL_BASE + "rmt/getRunningStatus"
+        try:
+            response = await self._post_request_with_logging_and_errors_raised(
+                url=url,
+                headers=headers,
+            )
+        except Exception as err:
+            _LOGGER.debug(
+                "Genesis action status check failed for %s; clearing tracked action: %s",
+                self.last_action.get("name"),
+                err,
+            )
+            self.last_action = None
+            return True
+        try:
+            response_json = await response.json()
+        except Exception:
+            _LOGGER.debug(
+                "Genesis action status returned no JSON for %s; clearing tracked action",
+                self.last_action.get("name"),
+            )
+            self.last_action = None
+            return True
+
+        status = str(response_json.get("status", "")).upper()
+        _LOGGER.debug("Genesis action status for %s: %s", action_id, status)
+        if status == "PENDING":
+            return False
+
+        self.last_action = None
         return True

--- a/custom_components/ha_kia_hyundai/kia_hyundai_api/us_hyundai.py
+++ b/custom_components/ha_kia_hyundai/kia_hyundai_api/us_hyundai.py
@@ -303,7 +303,7 @@ class UsHyundai:
     async def _post_request_with_logging_and_errors_raised(
             self,
             url: str,
-            json_body: dict,
+            json_body: dict | None = None,
             headers: dict | None = None,
     ) -> ClientResponse:
         if headers is None:
@@ -328,6 +328,28 @@ class UsHyundai:
             headers=headers,
             ssl=await self.get_ssl_context()
         )
+
+    def _get_transaction_id(self, response: ClientResponse) -> str | None:
+        """Return the BlueLink transaction ID from a command response."""
+        for key in ("tmsTid", "transactionId", "Xid"):
+            if key in response.headers:
+                return response.headers[key]
+        _LOGGER.warning(
+            "Hyundai command response did not include a transaction ID: %s",
+            dict(response.headers),
+        )
+        return None
+
+    def _set_last_action_from_response(self, name: str, response: ClientResponse) -> None:
+        """Track command transaction ID so refresh can wait for completion."""
+        transaction_id = self._get_transaction_id(response)
+        if transaction_id is None:
+            self.last_action = None
+            return
+        self.last_action = {
+            "name": name,
+            "id": transaction_id,
+        }
 
     async def login(self):
         """Login to Hyundai BlueLink with username/password (PIN used for commands)."""
@@ -687,6 +709,7 @@ class UsHyundai:
             headers=headers,
         )
         _LOGGER.debug("Hyundai lock response: %s", await response.text())
+        self._set_last_action_from_response("lock", response)
 
     async def unlock(self, vehicle_id: str):
         """Unlock the vehicle."""
@@ -707,6 +730,7 @@ class UsHyundai:
             headers=headers,
         )
         _LOGGER.debug("Hyundai unlock response: %s", await response.text())
+        self._set_last_action_from_response("unlock", response)
 
     async def start_climate(
             self,
@@ -773,6 +797,7 @@ class UsHyundai:
                 "airTemp": {"unit": 1, "value": set_temp},
                 "defrost": defrost,
                 "heating1": heating1_value,
+                "igniOnDuration": duration if duration is not None else 10,
                 "seatHeaterVentInfo": {
                     "drvSeatHeatState": _seat_settings_hyundai(driver_seat, vehicle_id),
                     "astSeatHeatState": _seat_settings_hyundai(passenger_seat, vehicle_id),
@@ -782,9 +807,6 @@ class UsHyundai:
                 "username": self.username,
                 "vin": vehicle.get("vin"),
             }
-            # Only include duration if user specified it
-            if duration is not None:
-                data["igniOnDuration"] = duration
 
         _LOGGER.debug("Hyundai start_climate data: %s", data)
 
@@ -794,6 +816,7 @@ class UsHyundai:
             headers=headers,
         )
         _LOGGER.debug("Hyundai start_climate response: %s", await response.text())
+        self._set_last_action_from_response("start_climate", response)
 
     async def stop_climate(self, vehicle_id: str):
         """Stop climate control."""
@@ -815,6 +838,7 @@ class UsHyundai:
             headers=headers,
         )
         _LOGGER.debug("Hyundai stop_climate response: %s", await response.text())
+        self._set_last_action_from_response("stop_climate", response)
 
     async def start_charge(self, vehicle_id: str):
         """Start charging (EV only)."""
@@ -834,6 +858,7 @@ class UsHyundai:
             headers=headers,
         )
         _LOGGER.debug("Hyundai start_charge response: %s", await response.text())
+        self._set_last_action_from_response("start_charge", response)
 
     async def stop_charge(self, vehicle_id: str):
         """Stop charging (EV only)."""
@@ -853,6 +878,7 @@ class UsHyundai:
             headers=headers,
         )
         _LOGGER.debug("Hyundai stop_charge response: %s", await response.text())
+        self._set_last_action_from_response("stop_charge", response)
 
     async def set_charge_limits(
             self,
@@ -884,8 +910,53 @@ class UsHyundai:
             headers=headers,
         )
         _LOGGER.debug("Hyundai set_charge_limits response: %s", await response.text())
+        self._set_last_action_from_response("set_charge_limits", response)
 
     async def check_last_action_finished(self, vehicle_id: str) -> bool:
-        """Check if last action is finished (placeholder for compatibility)."""
-        # Hyundai API doesn't have the same action tracking as Kia
+        """Check whether the last tracked Hyundai command has completed."""
+        if self.last_action is None:
+            return True
+
+        action_id = self.last_action.get("id")
+        if not action_id:
+            self.last_action = None
+            return True
+
+        await self._ensure_token_valid()
+        vehicle = await self.find_vehicle(vehicle_id)
+        headers = self._get_vehicle_headers(vehicle)
+        headers["tid"] = action_id
+        headers["login_id"] = self.username
+        headers["service_type"] = "REMOTE_POLL"
+
+        url = HYUNDAI_API_URL_BASE + "rmt/getRunningStatus"
+        try:
+            response = await self._post_request_with_logging_and_errors_raised(
+                url=url,
+                headers=headers,
+            )
+        except Exception as err:
+            _LOGGER.debug(
+                "Hyundai action status check failed for %s; clearing tracked action: %s",
+                self.last_action.get("name"),
+                err,
+            )
+            self.last_action = None
+            return True
+        try:
+            response_json = await response.json()
+        except Exception:
+            _LOGGER.debug(
+                "Hyundai action status returned no JSON for %s; clearing tracked action",
+                self.last_action.get("name"),
+            )
+            self.last_action = None
+            return True
+
+        status = str(response_json.get("status", "")).upper()
+        _LOGGER.debug("Hyundai action status for %s: %s", action_id, status)
+        if status == "PENDING":
+            return False
+
+        self.last_action = None
         return True

--- a/custom_components/ha_kia_hyundai/kia_hyundai_api/util_http.py
+++ b/custom_components/ha_kia_hyundai/kia_hyundai_api/util_http.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 from functools import wraps
@@ -7,6 +8,39 @@ from .errors import AuthError, ActionAlreadyInProgressError, PINLockedError
 from .util import clean_dictionary_for_logging
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _is_empty_body(response_text: str | None) -> bool:
+    """Return true when the API returned no usable response body."""
+    return response_text is None or response_text.strip() == ""
+
+
+def _is_success_status(response: ClientResponse) -> bool:
+    """Return true for HTTP statuses the API uses for successful commands."""
+    return 200 <= response.status < 300
+
+
+def _is_zero_error_code(error_code) -> bool:
+    """Return true when BlueLink's errorCode represents success."""
+    return str(error_code) in ("0", "200")
+
+
+def _extract_bluelink_error_message(response_json: dict) -> str:
+    """Return the most useful BlueLink error message available."""
+    return response_json.get(
+        "errorMessage",
+        response_json.get("errorSubMessage", "Unknown error"),
+    )
+
+
+def _is_bluelink_auth_error(url: str, error_code) -> bool:
+    """Return true when a BlueLink response should trigger reauthentication."""
+    # Upstream USA handling maps oauth/token errorCode 502 to auth failure, but
+    # vehicle endpoints can also return 502 for backend HATA failures.
+    if str(error_code) == "502" and url.endswith("/oauth/token"):
+        return True
+    return str(error_code) in ("401", "403", "1003", "1005")
+
 
 def request_with_active_session(func):
     @wraps(func)
@@ -114,15 +148,45 @@ def request_with_logging_bluelink(func):
             f"response headers:{clean_dictionary_for_logging(response.headers)}"
         )
 
-        # Check content type before trying to parse JSON
+        response_text = await response.text()
+
+        # Upstream USA BlueLink behavior: control commands can return HTTP 200
+        # with an empty body. Treat that as success instead of trying to parse
+        # JSON and surfacing a JSONDecodeError.
+        if _is_empty_body(response_text):
+            if _is_success_status(response):
+                _LOGGER.debug(
+                    "BlueLink API returned empty body with HTTP %s for %s; "
+                    "treating command as successful",
+                    response.status,
+                    url,
+                )
+                return response
+
+            raise ClientError(
+                f"BlueLink API error: HTTP {response.status} with empty response"
+            )
+
+        if not _is_success_status(response):
+            _LOGGER.debug(
+                "BlueLink API returned HTTP %s for %s. First 500 chars: %s",
+                response.status,
+                url,
+                response_text[:500],
+            )
+
         content_type = response.headers.get("Content-Type", "")
         if "application/json" not in content_type:
-            response_text = await response.text()
             _LOGGER.warning(
                 f"API returned non-JSON response (Content-Type: {content_type}). "
                 f"First 500 chars: {response_text[:500]}"
             )
-            raise AuthError(f"API returned non-JSON response (Content-Type: {content_type})")
+            if response.status in (401, 403):
+                raise AuthError(f"API returned non-JSON auth response (HTTP {response.status})")
+            raise ClientError(
+                f"API returned non-JSON response (HTTP {response.status}, "
+                f"Content-Type: {content_type})"
+            )
 
         try:
             response_json = await response.json()
@@ -132,8 +196,8 @@ def request_with_logging_bluelink(func):
 
             # BlueLink API error handling - different format than Kia
             # Check for error responses
-            if "errorCode" in response_json and response_json.get("errorCode") != 0:
-                error_msg = response_json.get("errorMessage", response_json.get("errorSubMessage", "Unknown error"))
+            if "errorCode" in response_json and not _is_zero_error_code(response_json.get("errorCode")):
+                error_msg = _extract_bluelink_error_message(response_json)
                 error_code = response_json.get("errorCode")
                 _LOGGER.debug(f"BlueLink API error: {error_code} - {error_msg}")
 
@@ -144,18 +208,23 @@ def request_with_logging_bluelink(func):
                     raise PINLockedError(f"BlueLink PIN locked: {error_msg}")
 
                 # Auth errors
-                if error_code in [401, 403, 1003, 1005]:
+                if _is_bluelink_auth_error(url, error_code):
                     raise AuthError(f"BlueLink auth error: {error_msg}")
 
                 raise ClientError(f"BlueLink API error: {error_msg}")
+
+            if not _is_success_status(response):
+                raise ClientError(f"BlueLink API error: HTTP {response.status}")
 
             # Success - return response
             return response
 
         except ContentTypeError as e:
-            response_text = await response.text()
             _LOGGER.warning(f"ContentTypeError parsing response: {e}. Text: {response_text[:500]}")
             raise AuthError(f"API returned invalid response: {e}")
+        except json.JSONDecodeError as e:
+            _LOGGER.warning(f"JSONDecodeError parsing response: {e}. Text: {response_text[:500]}")
+            raise ClientError(f"BlueLink API returned invalid JSON: {e}")
         except (AuthError, ClientError):
             raise
         except Exception as e:

--- a/custom_components/ha_kia_hyundai/manifest.json
+++ b/custom_components/ha_kia_hyundai/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/MarcusTaz/ha_kia_hyundai_USA/issues",
   "loggers": ["ha_kia_hyundai", "kia_hyundai_api"],
   "requirements": ["pytz>=2021.3"],
-  "version": "3.2.0"
+  "version": "3.2.1"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Port recent USA BlueLink response handling behavior for Hyundai/Genesis API calls
- Treat empty HTTP 2xx command responses as successful instead of surfacing JSON decode failures
- Normalize BlueLink `errorCode` handling while keeping oauth/token auth failures separate from vehicle-status backend failures
- Port latest USA command transaction tracking / action-status polling for Hyundai and Genesis commands
- Add `igniOnDuration` to Hyundai ICE climate-start payloads and bump manifest version to `3.2.1`

## Upstream notes
- `kia_uvo` v3.0.1 updates `hyundai_kia_connect_api` to v4.13.0
- `hyundai_kia_connect_api` v4.14.0 was also reviewed; its navigation feature is non-USA and was not ported

## Verification
- `python3 -m compileall custom_components/ha_kia_hyundai/kia_hyundai_api`
- `python3 -m ruff check custom_components/ha_kia_hyundai/kia_hyundai_api/util_http.py custom_components/ha_kia_hyundai/kia_hyundai_api/us_hyundai.py custom_components/ha_kia_hyundai/kia_hyundai_api/us_genesis.py`
- Focused async simulation of `request_with_logging_bluelink` for empty 2xx responses, string success `errorCode`, oauth/token 502 auth mapping, and vehicle-status 502 client-error mapping
- Focused async simulation of Hyundai/Genesis transaction tracking and pending/success action-status polling
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7161b869-60b6-458e-989b-5f8d8d5bcc11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7161b869-60b6-458e-989b-5f8d8d5bcc11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

