### PR TITLE
feat: Add plug-in hybrid (PHEV) support via evStatus='P' discriminator

### DIFF
--- a/custom_components/ha_kia_hyundai/kia_hyundai_api/us_hyundai.py
+++ b/custom_components/ha_kia_hyundai/kia_hyundai_api/us_hyundai.py
@@ -576,6 +576,7 @@ class UsHyundai:
         transformed = {
             "vinKey": vehicle.get("vin"),
             "vehicleConfig": {
+                "engineType": vehicle.get("evStatus", "N"),
                 "vehicleDetail": {
                     "vehicle": {
                         "vin": vehicle.get("vin"),
@@ -654,8 +655,8 @@ class UsHyundai:
             },
         }
 
-        # Add EV-specific data if applicable
-        if vehicle.get("evStatus") == "E":
+        # Add EV-specific data if applicable (EV "E" or PHEV "P")
+        if vehicle.get("evStatus") in ("E", "P") and vehicle_status.get("evStatus"):
             ev_status = vehicle_status.get("evStatus", {})
             transformed["lastVehicleInfo"]["vehicleStatusRpt"]["vehicleStatus"]["evStatus"] = {
                 "batteryCharge": ev_status.get("batteryCharge", False),

--- a/custom_components/ha_kia_hyundai/sensor.py
+++ b/custom_components/ha_kia_hyundai/sensor.py
@@ -114,7 +114,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[KiaSensorEntityDescription, ...]] = (
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         preserve_state=True,
-        exists_fn=lambda c: not c.is_ev,  # Only show for ICE/hybrid vehicles
+        exists_fn=lambda c: (not c.is_ev) or c.is_phev,  # Show for ICE and PHEV
     ),
     KiaSensorEntityDescription(
         key="fuel_remaining_range_value",

--- a/custom_components/ha_kia_hyundai/vehicle_coordinator.py
+++ b/custom_components/ha_kia_hyundai/vehicle_coordinator.py
@@ -189,6 +189,14 @@ class VehicleCoordinator(DataUpdateCoordinator):
         return ev_status is not None
 
     @property
+    def is_phev(self) -> bool:
+        """Return True if this is a plug-in hybrid (has both EV battery and fuel)."""
+        return safely_get_json_value(
+            self.data,
+            "vehicleConfig.engineType"
+        ) == "P"
+
+    @property
     def ev_battery_level(self) -> int | None:
         """Return EV battery percentage."""
         return safely_get_json_value(


### PR DESCRIPTION
## Problem

Plug-in hybrid vehicles (PHEVs) such as the **2023 Hyundai Santa Fe Plug-In Hybrid** return `evStatus == "P"` from the Hyundai cloud API, not `"E"` (full battery-electric). The current code branches on `evStatus == "E"` only, so PHEVs are classified as ICE: no EV battery sensor, no plugged-in/charging binary sensors, no charge switch, and no range-by-EV sensor are created.

## Root cause

In `kia_hyundai_api/us_hyundai.py`:
```python
# before
if vehicle.get("evStatus") == "E":
```
PHEVs report `evStatus == "P"` here and skip the entire EV-data ingestion block.

## Changes (4 hunks across 3 files)

### `kia_hyundai_api/us_hyundai.py` - broaden EV-data branch + expose engineType
```python
# after
if vehicle.get("evStatus") in ("E", "P") and vehicle_status.get("evStatus"):
```
Also adds `"engineType": vehicle.get("evStatus", "N")` to `vehicleConfig` so the coordinator can distinguish PHEV from EV without re-reading the status payload.

### `vehicle_coordinator.py` - new `is_phev` property
```python
@property
def is_phev(self) -> bool:
    """Return True if this is a plug-in hybrid (has both EV battery and fuel)."""
    return safely_get_json_value(self.data, "vehicleConfig.engineType") == "P"
```

### `sensor.py` - preserve fuel sensor for PHEVs
```python
# before
exists_fn=lambda c: not c.is_ev,  # Only show for ICE/hybrid vehicles
# after
exists_fn=lambda c: (not c.is_ev) or c.is_phev,  # Show for ICE and PHEV
```
Without this, a recognised PHEV (`is_ev == True`) loses its fuel-level entity.

## Impact

| Vehicle type | Before | After |
|---|---|---|
| Full EV (`evStatus="E"`) | EV entities, no fuel | unchanged |
| PHEV (`evStatus="P"`) | no EV entities, no fuel | EV + fuel entities |
| ICE/mild-hybrid (no evStatus) | fuel entities | unchanged |

## Testing

Verified on a **2023 Hyundai Santa Fe Plug-In Hybrid** (HA 2026.5.4, Python 3.12):

- Entity count on device: **33 to 38** (five new EV-side entities)
- `sensor.*_ev_battery`: **100 %**
- `binary_sensor.*_plugged_in`: **on**
- `binary_sensor.*_charging`: **off**
- `sensor.*_fuel_level`: **65.0 %** (preserved)
- `switch.*_charging`: present
- All three patched files pass `ast.parse`
