### PR TITLE
Fix unknown seat status handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@
 
 A Home Assistant integration for **Kia, Hyundai, and Genesis vehicles registered in the United States**. This is a community-maintained fork with active development.
 
+## Latest Update
+
+### v3.3.1 - Seat Status API Safety
+
+- Updated seat heat/vent status handling to match the latest upstream API safety fix.
+- Unknown seat status codes now show as unavailable instead of causing entity update failures.
+- Reviewed `kia_uvo` v3.1.0 / `hyundai_kia_connect_api` v4.14.1 and skipped non-USA window-option changes that this integration does not expose.
+
 ## Requirements
 
 - **USA Only** - Vehicles must be registered in the United States

--- a/custom_components/ha_kia_hyundai/manifest.json
+++ b/custom_components/ha_kia_hyundai/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/MarcusTaz/ha_kia_hyundai_USA/issues",
   "loggers": ["ha_kia_hyundai", "kia_hyundai_api"],
   "requirements": ["pytz>=2021.3"],
-  "version": "3.3.0"
+  "version": "3.3.1"
 }

--- a/custom_components/ha_kia_hyundai/sensor.py
+++ b/custom_components/ha_kia_hyundai/sensor.py
@@ -252,9 +252,9 @@ class SeatSensor(VehicleCoordinatorBaseEntity, SensorEntity):
     """Class for seat sensors."""
 
     @property
-    def native_value(self) -> str:
+    def native_value(self) -> str | None:
         """Return the state of the seat."""
-        return SEAT_STATUS[getattr(self.coordinator, self.entity_description.key)]
+        return SEAT_STATUS.get(getattr(self.coordinator, self.entity_description.key))
 
     @property
     def available(self) -> bool:
@@ -264,9 +264,12 @@ class SeatSensor(VehicleCoordinatorBaseEntity, SensorEntity):
     @property
     def icon(self) -> str:
         """Return an icon based on the seat state."""
-        if "Heat" in self.native_value:
+        native_value = self.native_value
+        if native_value is None:
+            return "mdi:car-seat"
+        if "Heat" in native_value:
             return "mdi:car-seat-heater"
-        if "Cool" in self.native_value:
+        if "Cool" in native_value:
             return "mdi:car-seat-cooler"
         return "mdi:car-seat"
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Port the USA-relevant safety behavior from `hyundai_kia_connect_api` v4.14.1 for unknown seat heat/vent status values
- Use a safe lookup for seat sensor labels so unmapped API values become unavailable instead of raising `KeyError`
- Bump manifest to `3.3.1` and add a brief README update note for HACS/GitHub users

## Upstream review
- Reviewed `kia_uvo` v3.1.0 and `hyundai_kia_connect_api` v4.14.1
- Skipped the v4.14.1 window-option enum conversion because this integration does not expose that API surface

## Verification
- `python3 -m compileall custom_components/ha_kia_hyundai`
- `python3 -m ruff check custom_components/ha_kia_hyundai/sensor.py`
- Focused seat-status regression simulation for known and unknown seat status values
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7161b869-60b6-458e-989b-5f8d8d5bcc11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7161b869-60b6-458e-989b-5f8d8d5bcc11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

