### PR TITLE
Add Genesis GV60 status fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ A Home Assistant integration for **Kia, Hyundai, and Genesis vehicles registered
 
 ## Latest Update
 
-### v3.3.1 - Seat Status API Safety
+### v3.3.2 - Genesis GV60 Status Fallback
 
-- Updated seat heat/vent status handling to match the latest upstream API safety fix.
-- Unknown seat status codes now show as unavailable instead of causing entity update failures.
-- Reviewed `kia_uvo` v3.1.0 / `hyundai_kia_connect_api` v4.14.1 and skipped non-USA window-option changes that this integration does not expose.
+- Added a narrow Genesis fallback for HATA `remoteVehicleStatus` 502 errors.
+- If cached Genesis vehicle status fails, the integration retries once with force refresh.
+- This targets GV60 setup failures without forcing refresh on every normal poll.
 
 ## Requirements
 

--- a/custom_components/ha_kia_hyundai/kia_hyundai_api/errors.py
+++ b/custom_components/ha_kia_hyundai/kia_hyundai_api/errors.py
@@ -32,3 +32,8 @@ class PINLockedError(AuthError):
 class TokenExpiredError(AuthError):
     """Raised when the access token has expired and needs refresh."""
     pass
+
+
+class HATARemoteVehicleStatusError(BaseError):
+    """Raised when HATA fails the BlueLink remoteVehicleStatus backend call."""
+    pass

--- a/custom_components/ha_kia_hyundai/kia_hyundai_api/us_genesis.py
+++ b/custom_components/ha_kia_hyundai/kia_hyundai_api/us_genesis.py
@@ -20,7 +20,7 @@ import time
 from functools import partial
 from aiohttp import ClientSession, ClientResponse
 
-from .errors import AuthError, PINLockedError
+from .errors import AuthError, HATARemoteVehicleStatusError, PINLockedError
 from .const import (
     GENESIS_API_URL_HOST,
     GENESIS_LOGIN_API_BASE,
@@ -157,6 +157,7 @@ class UsGenesis:
         self.pin = pin
         self.device_id = device_id or str(uuid.uuid4()).upper()
         self.token_expires_at = None
+        self._hata_force_refresh_attempted: set[str] = set()
         if client_session is None:
             self.api_session = ClientSession(raise_for_status=False)
         else:
@@ -461,10 +462,25 @@ class UsGenesis:
         headers = self._get_vehicle_headers(vehicle)
 
         url = GENESIS_API_URL_BASE + "rcs/rvs/vehicleStatus"
-        response = await self._get_request_with_logging_and_errors_raised(
-            url=url,
-            headers=headers,
-        )
+        try:
+            response = await self._get_request_with_logging_and_errors_raised(
+                url=url,
+                headers=headers,
+            )
+        except HATARemoteVehicleStatusError as err:
+            if vehicle_id in self._hata_force_refresh_attempted:
+                raise
+            self._hata_force_refresh_attempted.add(vehicle_id)
+            _LOGGER.warning(
+                "Genesis cached vehicle status failed; retrying once with force refresh: %s",
+                err,
+            )
+            force_headers = dict(headers)
+            force_headers["REFRESH"] = "true"
+            response = await self._get_request_with_logging_and_errors_raised(
+                url=url,
+                headers=force_headers,
+            )
         response_json = await response.json()
         _LOGGER.debug("Genesis vehicle status response: %s", response_json)
 

--- a/custom_components/ha_kia_hyundai/kia_hyundai_api/util_http.py
+++ b/custom_components/ha_kia_hyundai/kia_hyundai_api/util_http.py
@@ -4,7 +4,12 @@ import logging
 from functools import wraps
 from aiohttp import ClientError, ClientResponse, ContentTypeError
 
-from .errors import AuthError, ActionAlreadyInProgressError, PINLockedError
+from .errors import (
+    AuthError,
+    ActionAlreadyInProgressError,
+    HATARemoteVehicleStatusError,
+    PINLockedError,
+)
 from .util import clean_dictionary_for_logging
 
 _LOGGER = logging.getLogger(__name__)
@@ -40,6 +45,15 @@ def _is_bluelink_auth_error(url: str, error_code) -> bool:
     if str(error_code) == "502" and url.endswith("/oauth/token"):
         return True
     return str(error_code) in ("401", "403", "1003", "1005")
+
+
+def _is_hata_remote_vehicle_status_error(response_json: dict) -> bool:
+    """Return true for the USA Genesis HATA remoteVehicleStatus 502 failure."""
+    return (
+        str(response_json.get("errorCode")) == "502"
+        and response_json.get("systemName") == "HATA"
+        and response_json.get("functionName") == "remoteVehicleStatus"
+    )
 
 
 def request_with_active_session(func):
@@ -200,6 +214,9 @@ def request_with_logging_bluelink(func):
                 error_msg = _extract_bluelink_error_message(response_json)
                 error_code = response_json.get("errorCode")
                 _LOGGER.debug(f"BlueLink API error: {error_code} - {error_msg}")
+
+                if _is_hata_remote_vehicle_status_error(response_json):
+                    raise HATARemoteVehicleStatusError(f"BlueLink API error: {error_msg}")
 
                 # Check for PIN locked error - this is critical to detect
                 error_msg_upper = error_msg.upper() if error_msg else ""

--- a/custom_components/ha_kia_hyundai/manifest.json
+++ b/custom_components/ha_kia_hyundai/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/MarcusTaz/ha_kia_hyundai_USA/issues",
   "loggers": ["ha_kia_hyundai", "kia_hyundai_api"],
   "requirements": ["pytz>=2021.3"],
-  "version": "3.3.1"
+  "version": "3.3.2"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Detect the specific USA Genesis HATA `remoteVehicleStatus` 502 backend failure
- Retry Genesis cached vehicle status once per vehicle/API session with `REFRESH: true`
- Leave later cached 502s to the coordinator's stale-data fallback instead of force-refreshing every poll
- Bump manifest to `3.3.2` and update the README latest update note

## Context
- Matches reports in issue #25 for Genesis GV60 setup failures
- Aligns with upstream `Hyundai-Kia-Connect/hyundai_kia_connect_api#1163` while keeping the change narrow

## Verification
- `python3 -m compileall custom_components/ha_kia_hyundai`
- `python3 -m ruff check custom_components/ha_kia_hyundai/kia_hyundai_api/errors.py custom_components/ha_kia_hyundai/kia_hyundai_api/us_genesis.py custom_components/ha_kia_hyundai/kia_hyundai_api/util_http.py`
- Focused async simulation for HATA `remoteVehicleStatus` 502 detection
- Focused async simulation for one-time Genesis `REFRESH: true` fallback and no repeated force-refresh on later cached 502s
- GitHub CI: Ruff, Hassfest, and HACS validation passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7161b869-60b6-458e-989b-5f8d8d5bcc11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7161b869-60b6-458e-989b-5f8d8d5bcc11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

