### PR TITLE
Promote Genesis GV60 fixes to v3.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ A Home Assistant integration for **Kia, Hyundai, and Genesis vehicles registered
 
 ## Latest Update
 
-### v3.3.3-beta.2 - Genesis Location Fallback Test
+### v3.3.3 - Genesis GV60 Fixes
 
-- Beta test for Genesis/GV60 users seeing repeated `enrollment/details` errors.
+- Promotes tested Genesis/GV60 fixes from beta to stable.
 - Caches Genesis enrollment metadata after the first successful read.
 - Avoids polling that metadata endpoint on every normal status refresh.
 - Falls back to location coordinates from vehicle status if `findMyCar` times out.

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ A Home Assistant integration for **Kia, Hyundai, and Genesis vehicles registered
 
 ## Latest Update
 
-### v3.3.2 - Genesis GV60 Status Fallback
+### v3.3.3-beta.1 - Genesis Enrollment Cache Test
 
-- Added a narrow Genesis fallback for HATA `remoteVehicleStatus` 502 errors.
-- If cached Genesis vehicle status fails, the integration retries once with force refresh.
-- This targets GV60 setup failures without forcing refresh on every normal poll.
+- Beta test for Genesis/GV60 users seeing repeated `enrollment/details` errors.
+- Caches Genesis enrollment metadata after the first successful read.
+- Avoids polling that metadata endpoint on every normal status refresh.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ A Home Assistant integration for **Kia, Hyundai, and Genesis vehicles registered
 
 ## Latest Update
 
-### v3.3.3-beta.1 - Genesis Enrollment Cache Test
+### v3.3.3-beta.2 - Genesis Location Fallback Test
 
 - Beta test for Genesis/GV60 users seeing repeated `enrollment/details` errors.
 - Caches Genesis enrollment metadata after the first successful read.
 - Avoids polling that metadata endpoint on every normal status refresh.
+- Falls back to location coordinates from vehicle status if `findMyCar` times out.
 
 ## Requirements
 

--- a/custom_components/ha_kia_hyundai/device_tracker.py
+++ b/custom_components/ha_kia_hyundai/device_tracker.py
@@ -1,7 +1,7 @@
 from logging import getLogger
 
-from homeassistant.components.device_tracker import SourceType, TrackerEntityDescription
-from homeassistant.components.device_tracker.config_entry import TrackerEntity
+from homeassistant.components.device_tracker import TrackerEntity, TrackerEntityDescription
+from homeassistant.components.device_tracker.const import SourceType
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback

--- a/custom_components/ha_kia_hyundai/kia_hyundai_api/us_genesis.py
+++ b/custom_components/ha_kia_hyundai/kia_hyundai_api/us_genesis.py
@@ -158,6 +158,7 @@ class UsGenesis:
         self.device_id = device_id or str(uuid.uuid4()).upper()
         self.token_expires_at = None
         self._hata_force_refresh_attempted: set[str] = set()
+        self._enrollment_details_cache: dict | None = None
         if client_session is None:
             self.api_session = ClientSession(raise_for_status=False)
         else:
@@ -412,15 +413,7 @@ class UsGenesis:
         """Get list of vehicles for the account."""
         await self._ensure_token_valid()
 
-        url = GENESIS_API_URL_BASE + "enrollment/details/" + self.username
-        headers = self._get_authenticated_headers()
-
-        response = await self._get_request_with_logging_and_errors_raised(
-            url=url,
-            headers=headers,
-        )
-
-        response_json = await response.json()
+        response_json = await self._get_enrollment_details(force_refresh=True)
         _LOGGER.debug("Genesis get_vehicles response: %s", response_json)
 
         self.vehicles = []
@@ -454,6 +447,19 @@ class UsGenesis:
                 return vehicle
         raise ValueError(f"Vehicle {vehicle_id} not found")
 
+    async def _get_enrollment_details(self, force_refresh: bool = False) -> dict:
+        """Return cached Genesis enrollment metadata."""
+        if self._enrollment_details_cache is not None and not force_refresh:
+            return self._enrollment_details_cache
+
+        url = GENESIS_API_URL_BASE + "enrollment/details/" + self.username
+        response = await self._get_request_with_logging_and_errors_raised(
+            url=url,
+            headers=self._get_authenticated_headers(),
+        )
+        self._enrollment_details_cache = await response.json()
+        return self._enrollment_details_cache
+
     async def get_cached_vehicle_status(self, vehicle_id: str):
         """Get cached vehicle status from Genesis API."""
         await self._ensure_token_valid()
@@ -484,13 +490,8 @@ class UsGenesis:
         response_json = await response.json()
         _LOGGER.debug("Genesis vehicle status response: %s", response_json)
 
-        # Get vehicle details
-        details_url = GENESIS_API_URL_BASE + "enrollment/details/" + self.username
-        details_response = await self._get_request_with_logging_and_errors_raised(
-            url=details_url,
-            headers=self._get_authenticated_headers(),
-        )
-        details_json = await details_response.json()
+        # Enrollment details are metadata/capabilities; avoid polling this endpoint every refresh.
+        details_json = await self._get_enrollment_details()
 
         vehicle_details = {}
         seat_configs = []

--- a/custom_components/ha_kia_hyundai/kia_hyundai_api/us_genesis.py
+++ b/custom_components/ha_kia_hyundai/kia_hyundai_api/us_genesis.py
@@ -554,13 +554,19 @@ class UsGenesis:
             fatc_available, bluelink_enabled
         )
 
-        # Get location
+        vehicle_status = response_json.get("vehicleStatus", {})
+
+        # Get location; GV60 may expose coordinates in vehicleStatus while findMyCar times out.
         location = None
         try:
             loc_url = GENESIS_API_URL_BASE + "rcs/rfc/findMyCar"
-            loc_response = await self._get_request_with_logging_and_errors_raised(
-                url=loc_url,
-                headers=headers,
+            _LOGGER.debug("Genesis findMyCar URL: %s", loc_url)
+            loc_response = await asyncio.wait_for(
+                self._get_request_with_logging_and_errors_raised(
+                    url=loc_url,
+                    headers=headers,
+                ),
+                timeout=10,
             )
             loc_json = await loc_response.json()
             if loc_json.get("coord"):
@@ -568,9 +574,13 @@ class UsGenesis:
         except Exception as e:
             _LOGGER.debug("Failed to get location: %s", e)
 
-        # Transform to match Kia format
-        vehicle_status = response_json.get("vehicleStatus", {})
+        if location is None:
+            status_location = vehicle_status.get("vehicleLocation") or {}
+            if status_location.get("coord"):
+                _LOGGER.debug("Using Genesis vehicleStatus location fallback")
+                location = status_location
 
+        # Transform to match Kia format
         transformed = {
             "vinKey": vehicle.get("vin"),
             "vehicleConfig": {

--- a/custom_components/ha_kia_hyundai/manifest.json
+++ b/custom_components/ha_kia_hyundai/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/MarcusTaz/ha_kia_hyundai_USA/issues",
   "loggers": ["ha_kia_hyundai", "kia_hyundai_api"],
   "requirements": ["pytz>=2021.3"],
-  "version": "3.3.3-beta.2"
+  "version": "3.3.3"
 }

--- a/custom_components/ha_kia_hyundai/manifest.json
+++ b/custom_components/ha_kia_hyundai/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/MarcusTaz/ha_kia_hyundai_USA/issues",
   "loggers": ["ha_kia_hyundai", "kia_hyundai_api"],
   "requirements": ["pytz>=2021.3"],
-  "version": "3.3.3-beta.1"
+  "version": "3.3.3-beta.2"
 }

--- a/custom_components/ha_kia_hyundai/manifest.json
+++ b/custom_components/ha_kia_hyundai/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/MarcusTaz/ha_kia_hyundai_USA/issues",
   "loggers": ["ha_kia_hyundai", "kia_hyundai_api"],
   "requirements": ["pytz>=2021.3"],
-  "version": "3.3.2"
+  "version": "3.3.3-beta.1"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Promote the tested Genesis/GV60 beta fixes to stable `v3.3.3`
- Cache Genesis enrollment metadata after the first successful read
- Reuse cached metadata during normal status polling instead of calling `enrollment/details` every refresh
- Add a timeout around Genesis `findMyCar` and fall back to `vehicleStatus.vehicleLocation.coord` when available
- Update Home Assistant device tracker imports away from the deprecated path

## Validation from beta testing
- `v3.3.3-beta.1` resolved repeated `enrollment/details` chunk errors
- `v3.3.3-beta.2` restored GV60 location, improved startup delay, kept polling and commands working

## Verification
- Local and CI checks to follow after stable metadata update
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7161b869-60b6-458e-989b-5f8d8d5bcc11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7161b869-60b6-458e-989b-5f8d8d5bcc11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

